### PR TITLE
changes to score transform

### DIFF
--- a/packages/cis_kubernetes_benchmark/changelog.yml
+++ b/packages/cis_kubernetes_benchmark/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.0.4"
+  changes:
+    - description: Change score transform
+      type: enhancement
+      link: https://github.com/build-security/integrations/pull/20
 - version: "0.0.3"
   changes:
     - description: Add latest findings transform and benchmark score pivot transform

--- a/packages/cis_kubernetes_benchmark/elasticsearch/transform/score/default.json
+++ b/packages/cis_kubernetes_benchmark/elasticsearch/transform/score/default.json
@@ -1,89 +1,82 @@
 {
-    "description": "Calculate latest findings score",
-    "source": {
-        "index": "logs-cloud_security_posture.findings_latest-default"
-    },
-    "dest": {
-        "index": "logs-cloud_security_posture.scores-default"
-    },
-    "frequency": "30m",
-    "sync": {
-        "time": {
-            "field": "event.ingested",
-            "delay": "60s"
-        }
-    },
-    "retention_policy": {
-        "time": {
-            "field": "@timestamp",
-            "max_age": "30d"
-        }
-    },
-    "pivot": {
-        "group_by": {
-            "rule.benchmark.name": {
-                "terms": {
-                    "field": "rule.benchmark.name.keyword"
-                }
-            },
-            "cluster_id": {
-                "terms": {
-                    "field": "cluster_id.keyword"
-                }
-            },
-            "@timestamp": {
-                "date_histogram": {
-                    "field": "@timestamp",
-                    "calendar_interval": "1m"
-                }
-            }
-        },
-        "aggregations": {
-            "total_findings": {
-                "value_count": {
-                    "field": "result.evaluation.keyword"
-                }
-            },
-            "passed": {
-                "filter": {
-                    "term": {
-                        "result.evaluation.keyword": "passed"
-                    }
-                },
-                "aggs": {
-                    "passed_counter": {
-                        "value_count": {
-                            "field": "result.evaluation.keyword"
-                        }
-                    }
-                }
-            },
-            "failed": {
-                "filter": {
-                    "term": {
-                        "result.evaluation.keyword": "failed"
-                    }
-                },
-                "aggs": {
-                    "failed_counter": {
-                        "value_count": {
-                            "field": "result.evaluation.keyword"
-                        }
-                    }
-                }
-            },
-            "score": {
-                "bucket_script": {
-                    "buckets_path": {
-                        "passed": "passed\u003epassed_counter",
-                        "total": "total_findings"
-                    },
-                    "script": "params.passed / params.total"
-                }
-            }
-        }
-    },
-    "_meta": {
-        "managed": true
+  "description": "Calculate latest findings score",
+  "source": {
+    "index": "logs-cloud_security_posture.findings_latest-default"
+  },
+  "dest": {
+    "index": "logs-cloud_security_posture.scores-default"
+  },
+  "frequency": "30m",
+  "sync": {
+    "time": {
+      "field": "event.ingested",
+      "delay": "60s"
     }
+  },
+  "retention_policy": {
+    "time": {
+      "field": "@timestamp",
+      "max_age": "30d"
+    }
+  },
+  "pivot": {
+    "group_by": {
+      "@timestamp": {
+        "date_histogram": {
+          "field": "@timestamp",
+          "calendar_interval": "1m"
+        }
+      }
+    },
+    "aggs": {
+      "total_findings": {
+        "value_count": {
+          "field": "result.evaluation.keyword"
+        }
+      },
+      "passed_findings": {
+        "filter": {
+          "term": {
+            "result.evaluation.keyword": "passed"
+          }
+        }
+      },
+      "failed_findings": {
+        "filter": {
+          "term": {
+            "result.evaluation.keyword": "failed"
+          }
+        }
+      },
+      "score_by_cluster_id": {
+        "terms": {
+          "field": "cluster_id.keyword"
+        },
+        "aggs": {
+          "total_findings": {
+            "value_count": {
+              "field": "result.evaluation.keyword"
+            }
+          },
+          "passed_findings": {
+            "filter": {
+              "term": {
+                "result.evaluation.keyword": "passed"
+              }
+            }
+          },
+          "failed_findings": {
+            "filter": {
+              "term": {
+                "result.evaluation.keyword": "failed"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "_meta": {
+    "managed": true
+  }
 }


### PR DESCRIPTION
## Summary
This PR changes the aggregations done by the `score` transform.
Previously this `transform` would create a doc per `cluster_id`, which made it difficult to create a time-based trendline.
After the changes docs will contain the findings evaluations counters at a certain time point, for both the summary section and per cluster.

## Doc _source example
```
"_source": {
    "@timestamp": "2022-04-06T12:38:00.000Z",
    "total_findings": 213,
    "passed_findings": 168,
    "failed_findings": 45
         "score_by_cluster_id": {
             "6e7c19ba-6125-48b8-8886-c738c7b9f984": {
                "total_findings": 213,
                "passed_findings": 168,
                "failed_findings": 45
              }
        },
  },
```

## Usage
- https://github.com/elastic/kibana/pull/129481

Creates a trend line for both the summary and per cluster using this interface by querying for a certain amount of docs while sorting them in descending order.